### PR TITLE
Added DateTime.

### DIFF
--- a/src/roblox/init.lua
+++ b/src/roblox/init.lua
@@ -945,6 +945,8 @@ local function bitBuffer(stream)
     end
 
     local function writeDateTime(dateTime)
+        assert(typeof(dateTime) == "DateTime", "argument #1 to BitBuffer.writeDateTime should be a DateTime")
+
         local universalTime = dateTime:ToUniversalTime()
         writeUnsigned(14, universalTime.Year)
         writeUnsigned(4, universalTime.Month)

--- a/src/roblox/init.lua
+++ b/src/roblox/init.lua
@@ -1501,6 +1501,8 @@ local function bitBuffer(stream)
     end
 
     local function readDateTime()
+        assert(pointer + 50 <= bitCount, "BitBuffer.readDateTime cannot read past the end of the stream")
+
         return DateTime.fromUniversalTime(
             readUnsigned(14),
             readUnsigned(4),

--- a/src/roblox/tests/spec/datetime.lua
+++ b/src/roblox/tests/spec/datetime.lua
@@ -64,7 +64,7 @@ local function makeTests(try)
         assert(buffer.readDateTime() == DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500), "")
     end).pass()
 
-    readTest("Should read a bit from the stream properly after a Ray", function()
+    readTest("Should read a bit from the stream properly after a DateTime", function()
         local buffer = BitBuffer()
 
         buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))

--- a/src/roblox/tests/spec/datetime.lua
+++ b/src/roblox/tests/spec/datetime.lua
@@ -1,0 +1,91 @@
+--!nocheck
+local BitBuffer = require(script.Parent.Parent.Parent)
+
+local function makeTests(try)
+    local writeTest = try("writeDateTime tests")
+    local readTest = try("readDateTime tests")
+
+    writeTest("Should require the argument be a DateTime", function()
+        local buffer = BitBuffer()
+
+        buffer.writeDateTime({})
+    end).fail()
+
+    writeTest("Should write to the stream properly", function()
+        local buffer = BitBuffer()
+
+        buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))
+
+        assert(buffer.dumpBinary() == "00011111 10010010 01100010 11000001 01011110 01111101 00", "")
+    end).pass()
+
+    writeTest("Should write to the stream properly after a bit", function()
+        local buffer = BitBuffer()
+
+        buffer.writeBits(1)
+        buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))
+
+        assert(buffer.dumpBinary() == "10001111 11001001 00110001 01100000 10101111 00111110 100", "")
+    end).pass()
+
+    writeTest("Should write a bit to the stream properly after a DateTime", function()
+        local buffer = BitBuffer()
+
+        buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))
+        buffer.writeBits(1)
+
+        assert(buffer.dumpBinary() == "00011111 10010010 01100010 11000001 01011110 01111101 001", "")
+    end).pass()
+
+    readTest("Should require no arguments", function()
+        local buffer = BitBuffer()
+
+        buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))
+
+        buffer.readDateTime()
+    end).pass()
+
+    readTest("Should read from the stream properly", function()
+        local buffer = BitBuffer()
+
+        buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))
+
+        assert(buffer.readDateTime() == DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500), "")
+    end).pass()
+
+    readTest("Should read from the stream properly after a bit", function()
+        local buffer = BitBuffer()
+
+        buffer.writeBits(1)
+        buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))
+
+        buffer.readBits(1)
+
+        assert(buffer.readDateTime() == DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500), "")
+    end).pass()
+
+    readTest("Should read a bit from the stream properly after a Ray", function()
+        local buffer = BitBuffer()
+
+        buffer.writeDateTime(DateTime.fromUniversalTime(2020, 9, 17, 12, 5, 30, 500))
+        buffer.writeBits(1)
+
+        buffer.readDateTime()
+
+        assert(buffer.readBits(1)[1] == 1, "")
+    end).pass()
+
+    readTest("Should not allow reading past the end of the stream", function()
+        local buffer = BitBuffer()
+
+        buffer.readDateTime()
+    end).fail()
+
+    local writeTestPassed = writeTest.run()
+    local readTestPassed = readTest.run()
+
+
+    return writeTestPassed and readTestPassed
+end
+
+return makeTests


### PR DESCRIPTION
Added DateTime support. Saves a DateTime in the most efficient format, saving it to 7 characters versus 21 characters as a terminated string.